### PR TITLE
convert and add test segment-tree

### DIFF
--- a/src/main/kotlin/jp/atcoder/library/kotlin/segTree/SegTree.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/segTree/SegTree.kt
@@ -1,7 +1,5 @@
 package jp.atcoder.library.kotlin.segTree
 
-import java.util.*
-
 /**
  * Segment tree(0-indexed)
  */
@@ -22,7 +20,6 @@ class SegTree<S>(private val size: Int, private val e: S, private val op: (S, S)
         innerSize = k
         @Suppress("UNCHECKED_CAST")
         data = Array(innerSize shl 1) { e as Any } as Array<S>
-        Arrays.fill(data, this.e)
     }
 
     operator fun set(p: Int, x: S) {

--- a/src/main/kotlin/jp/atcoder/library/kotlin/segTree/SegTree.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/segTree/SegTree.kt
@@ -1,0 +1,128 @@
+package jp.atcoder.library.kotlin.segTree
+
+import java.util.*
+
+/**
+ * Segment tree(0-indexed)
+ */
+class SegTree<S>(private val size: Int, private val e: S, private val op: (S, S) -> S) {
+    private val innerSize: Int
+    private val data: Array<S>
+
+    constructor(dat: Array<S>, e: S, op: (S, S) -> S) : this(dat.size, e, op) {
+        System.arraycopy(dat, 0, data, innerSize, dat.size)
+        for (i in innerSize - 1 downTo 1) {
+            data[i] = op(data[i shl 1 or 0], data[i shl 1 or 1])
+        }
+    }
+
+    init {
+        var k = 1
+        while (k < size) k = k shl 1
+        innerSize = k
+        @Suppress("UNCHECKED_CAST")
+        data = Array(innerSize shl 1) { e as Any } as Array<S>
+        Arrays.fill(data, this.e)
+    }
+
+    operator fun set(p: Int, x: S) {
+        var vp = p
+        exclusiveRangeCheck(vp)
+        data[innerSize.let { vp += it; vp }] = x
+        vp = vp shr 1
+        while (vp > 0) {
+            data[vp] = op(data[vp shl 1 or 0], data[vp shl 1 or 1])
+            vp = vp shr 1
+        }
+    }
+
+    operator fun get(p: Int): S {
+        exclusiveRangeCheck(p)
+        return data[p + innerSize]
+    }
+
+    fun prod(l: Int, r: Int): S {
+        var vl = l
+        var vr = r
+        require(vl <= vr) { String.format("Invalid range: [%d, %d)", vl, vr) }
+        inclusiveRangeCheck(vl)
+        inclusiveRangeCheck(vr)
+        var sumLeft = e
+        var sumRight = e
+        vl += innerSize
+        vr += innerSize
+        while (vl < vr) {
+            if (vl and 1 == 1) sumLeft = op(sumLeft, data[vl++])
+            if (vr and 1 == 1) sumRight = op(data[--vr], sumRight)
+            vl = vl shr 1
+            vr = vr shr 1
+        }
+        return op(sumLeft, sumRight)
+    }
+
+    fun allProd(): S {
+        return data[1]
+    }
+
+    fun maxRight(l: Int, f: (S) -> Boolean): Int {
+        var vl = l
+        inclusiveRangeCheck(vl)
+        require(f(e)) { "Identity element must satisfy the condition." }
+        if (vl == size) return size
+        vl += innerSize
+        var sum = e
+        do {
+            vl = vl shr Integer.numberOfTrailingZeros(vl)
+            if (!f(op(sum, data[vl]))) {
+                while (vl < innerSize) {
+                    vl = vl shl 1
+                    if (f(op(sum, data[vl]))) {
+                        sum = op(sum, data[vl])
+                        vl++
+                    }
+                }
+                return vl - innerSize
+            }
+            sum = op(sum, data[vl])
+            vl++
+        } while (vl and -vl != vl)
+        return size
+    }
+
+    fun minLeft(r: Int, f: (S) -> Boolean): Int {
+        var vr = r
+        inclusiveRangeCheck(vr)
+        require(f(e)) { "Identity element must satisfy the condition." }
+        if (vr == 0) return 0
+        vr += innerSize
+        var sum = e
+        do {
+            vr--
+            while (vr > 1 && vr and 1 == 1) vr = vr shr 1
+            if (!f(op(data[vr], sum))) {
+                while (vr < innerSize) {
+                    vr = vr shl 1 or 1
+                    if (f(op(data[vr], sum))) {
+                        sum = op(data[vr], sum)
+                        vr--
+                    }
+                }
+                return vr + 1 - innerSize
+            }
+            sum = op(data[vr], sum)
+        } while (vr and -vr != vr)
+        return 0
+    }
+
+    private fun exclusiveRangeCheck(p: Int) {
+        if (p < 0 || p >= size) {
+            throw IndexOutOfBoundsException("Index $p out of bounds for the range [0, $size).")
+        }
+    }
+
+    private fun inclusiveRangeCheck(p: Int) {
+        if (p < 0 || p > size) {
+            throw IndexOutOfBoundsException("Index $p out of bounds for the range [0, $size].")
+        }
+    }
+}

--- a/src/test/kotlin/jp/atcoder/library/kotlin/segTree/SegTreeTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/segTree/SegTreeTest.kt
@@ -1,0 +1,59 @@
+package jp.atcoder.library.kotlin.segTree
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class SegTreeTest {
+    @Test
+    fun segTreeSum() {
+        SegTree(arrayOf(1, 2, 3), 0, Int::plus).run {
+            // [1, 2, 3]
+            assertThat(prod(0, 0)).isEqualTo(0)
+            assertThat(prod(0, 1)).isEqualTo(1)
+            assertThat(prod(0, 3)).isEqualTo(6)
+            assertThat(prod(3, 3)).isEqualTo(0)
+            assertThat(allProd()).isEqualTo(6)
+
+            // [4, 2, 3]
+            this[0] = 4
+
+            assertThat(prod(0, 0)).isEqualTo(0)
+            assertThat(prod(0, 1)).isEqualTo(4)
+            assertThat(prod(0, 3)).isEqualTo(9)
+            assertThat(prod(3, 3)).isEqualTo(0)
+            assertThat(allProd()).isEqualTo(9)
+        }
+    }
+
+    @Test
+    fun segTreeMax() {
+        SegTree(arrayOf(1, 2, 3), -1, Math::max).run {
+            // [1, 2, 3]
+            assertThat(prod(0, 0)).isEqualTo(-1)
+            assertThat(prod(0, 1)).isEqualTo(1)
+            assertThat(prod(0, 3)).isEqualTo(3)
+            assertThat(prod(3, 3)).isEqualTo(-1)
+            assertThat(allProd()).isEqualTo(3)
+
+            assertThat(minLeft(0) { it < 2 }).isEqualTo(0)
+            assertThat(minLeft(1) { it < 2 }).isEqualTo(0)
+            assertThat(minLeft(2) { it < 2 }).isEqualTo(2)
+            assertThat(minLeft(3) { it < 2 }).isEqualTo(3)
+
+            assertThat(maxRight(0) { it < 2 }).isEqualTo(1)
+            assertThat(maxRight(1) { it < 2 }).isEqualTo(1)
+            assertThat(maxRight(2) { it < 2 }).isEqualTo(2)
+            assertThat(maxRight(3) { it < 2 }).isEqualTo(3)
+
+            // [4, 2, 3]
+            this[0] = 4
+
+            assertThat(prod(0, 0)).isEqualTo(-1)
+            assertThat(prod(0, 1)).isEqualTo(4)
+            assertThat(prod(0, 3)).isEqualTo(4)
+            assertThat(prod(3, 3)).isEqualTo(-1)
+            assertThat(allProd()).isEqualTo(4)
+        }
+    }
+}
+


### PR DESCRIPTION
# 概要

- #2 convert, test の追加

# Java版からの変更点
- `op`などの型を`BinaryOperator`などではなくKotlinの関数型に変更
  - これによってこんな感じにラムダ式で渡すことができる
  ```kotlin
  SegTree(arrayOf(1, 2, 3), -1) { a, b -> Math.max(a, b) }
  ```
  - 参照渡しでも解決してくれる
  ```kotlin
  SegTree(arrayOf(1, 2, 3), -1, Math::max)
  ```
- 上記の書き方ができるようにするため`op`などの関数型を引数の最後に移動
- 内部の変数名の変更（これはリファクタリングでやればよかった……）
- etc.