### PR TITLE
MathLibのコンバート

### DIFF
--- a/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
@@ -1,6 +1,9 @@
 package jp.atcoder.library.kotlin.math
 
 internal object MathLib {
+    /**
+     * xをmで割った余りを返す.
+     */
     fun safeMod(x: Long, m: Long): Long {
         var x = x
         x %= m
@@ -31,6 +34,9 @@ internal object MathLib {
         return longArrayOf(s, m0)
     }
 
+    /**
+     * xのn乗をmで割った余りを返す.
+     */
     fun powMod(x: Long, n: Long, m: Long): Long {
         var x = x
         var n = n

--- a/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
@@ -1,16 +1,16 @@
 package jp.atcoder.library.kotlin.math
 
 internal object MathLib {
-    private fun safe_mod(x: Long, m: Long): Long {
+    private fun safeMod(x: Long, m: Long): Long {
         var x = x
         x %= m
         if (x < 0) x += m
         return x
     }
 
-    private fun inv_gcd(a: Long, b: Long): LongArray {
+    private fun invGcd(a: Long, b: Long): LongArray {
         var a = a
-        a = safe_mod(a, b)
+        a = safeMod(a, b)
         if (a == 0L) return longArrayOf(b, 0)
         var s = b
         var t = a
@@ -31,7 +31,7 @@ internal object MathLib {
         return longArrayOf(s, m0)
     }
 
-    fun pow_mod(x: Long, n: Long, m: Long): Long {
+    fun powMod(x: Long, n: Long, m: Long): Long {
         var x = x
         var n = n
         assert(n >= 0 && m >= 1)
@@ -51,7 +51,7 @@ internal object MathLib {
         var m0: Long = 1
         for (i in 0 until n) {
             assert(1 <= m[i])
-            var r1 = safe_mod(r[i], m[i])
+            var r1 = safeMod(r[i], m[i])
             var m1 = m[i]
             if (m0 < m1) {
                 var tmp = r0
@@ -65,7 +65,7 @@ internal object MathLib {
                 if (r0 % m1 != r1) return longArrayOf(0, 0)
                 continue
             }
-            val ig = inv_gcd(m0, m1)
+            val ig = invGcd(m0, m1)
             val g = ig[0]
             val im = ig[1]
             val u1 = m1 / g
@@ -79,7 +79,7 @@ internal object MathLib {
         return longArrayOf(r0, m0)
     }
 
-    fun floor_sum(n: Long, m: Long, a: Long, b: Long): Long {
+    fun floorSum(n: Long, m: Long, a: Long, b: Long): Long {
         var a = a
         var b = b
         var ans: Long = 0
@@ -91,11 +91,11 @@ internal object MathLib {
             ans += n * (b / m)
             b %= m
         }
-        val y_max = (a * n + b) / m
-        val x_max = y_max * m - b
-        if (y_max == 0L) return ans
-        ans += (n - (x_max + a - 1) / a) * y_max
-        ans += floor_sum(y_max, a, m, (a - x_max % a) % a)
+        val yMax = (a * n + b) / m
+        val xMax = yMax * m - b
+        if (yMax == 0L) return ans
+        ans += (n - (xMax + a - 1) / a) * yMax
+        ans += floorSum(yMax, a, m, (a - xMax % a) % a)
         return ans
     }
 }

--- a/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
@@ -1,0 +1,101 @@
+package jp.atcoder.library.kotlin.math
+
+internal object MathLib {
+    private fun safe_mod(x: Long, m: Long): Long {
+        var x = x
+        x %= m
+        if (x < 0) x += m
+        return x
+    }
+
+    private fun inv_gcd(a: Long, b: Long): LongArray {
+        var a = a
+        a = safe_mod(a, b)
+        if (a == 0L) return longArrayOf(b, 0)
+        var s = b
+        var t = a
+        var m0: Long = 0
+        var m1: Long = 1
+        while (t > 0) {
+            val u = s / t
+            s -= t * u
+            m0 -= m1 * u
+            var tmp = s
+            s = t
+            t = tmp
+            tmp = m0
+            m0 = m1
+            m1 = tmp
+        }
+        if (m0 < 0) m0 += b / s
+        return longArrayOf(s, m0)
+    }
+
+    fun pow_mod(x: Long, n: Long, m: Long): Long {
+        var x = x
+        var n = n
+        assert(n >= 0 && m >= 1)
+        var ans: Long = 1
+        while (n > 0) {
+            if (n % 2 == 1L) ans = ans * x % m
+            x = x * x % m
+            n /= 2
+        }
+        return ans
+    }
+
+    fun crt(r: LongArray, m: LongArray): LongArray {
+        assert(r.size == m.size)
+        val n = r.size
+        var r0: Long = 0
+        var m0: Long = 1
+        for (i in 0 until n) {
+            assert(1 <= m[i])
+            var r1 = safe_mod(r[i], m[i])
+            var m1 = m[i]
+            if (m0 < m1) {
+                var tmp = r0
+                r0 = r1
+                r1 = tmp
+                tmp = m0
+                m0 = m1
+                m1 = tmp
+            }
+            if (m0 % m1 == 0L) {
+                if (r0 % m1 != r1) return longArrayOf(0, 0)
+                continue
+            }
+            val ig = inv_gcd(m0, m1)
+            val g = ig[0]
+            val im = ig[1]
+            val u1 = m1 / g
+            if ((r1 - r0) % g != 0L) return longArrayOf(0, 0)
+            val x = (r1 - r0) / g % u1 * im % u1
+            r0 += x * m0
+            m0 *= u1
+            if (r0 < 0) r0 += m0
+            //System.err.printf("%d %d\n", r0, m0);
+        }
+        return longArrayOf(r0, m0)
+    }
+
+    fun floor_sum(n: Long, m: Long, a: Long, b: Long): Long {
+        var a = a
+        var b = b
+        var ans: Long = 0
+        if (a >= m) {
+            ans += (n - 1) * n * (a / m) / 2
+            a %= m
+        }
+        if (b >= m) {
+            ans += n * (b / m)
+            b %= m
+        }
+        val y_max = (a * n + b) / m
+        val x_max = y_max * m - b
+        if (y_max == 0L) return ans
+        ans += (n - (x_max + a - 1) / a) * y_max
+        ans += floor_sum(y_max, a, m, (a - x_max % a) % a)
+        return ans
+    }
+}

--- a/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
@@ -5,10 +5,8 @@ internal object MathLib {
      * xをmで割った余りを返す.
      */
     fun safeMod(x: Long, m: Long): Long {
-        var x = x
-        x %= m
-        if (x < 0) x += m
-        return x
+        val x = x % m
+        return if (x < 0) x + m else x
     }
 
     fun invGcd(a: Long, b: Long): LongArray {

--- a/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
@@ -36,10 +36,10 @@ internal object MathLib {
      * xのn乗をmで割った余りを返す.
      */
     fun powMod(x: Long, n: Long, m: Long): Long {
+        assert(n >= 0 && m >= 1)
         var x = x
         var n = n
-        assert(n >= 0 && m >= 1)
-        var ans: Long = 1
+        var ans = 1L
         while (n > 0) {
             if (n % 2 == 1L) ans = ans * x % m
             x = x * x % m

--- a/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/math/MathLib.kt
@@ -1,14 +1,14 @@
 package jp.atcoder.library.kotlin.math
 
 internal object MathLib {
-    private fun safeMod(x: Long, m: Long): Long {
+    fun safeMod(x: Long, m: Long): Long {
         var x = x
         x %= m
         if (x < 0) x += m
         return x
     }
 
-    private fun invGcd(a: Long, b: Long): LongArray {
+    fun invGcd(a: Long, b: Long): LongArray {
         var a = a
         a = safeMod(a, b)
         if (a == 0L) return longArrayOf(b, 0)

--- a/src/test/kotlin/jp/atcoder/library/kotlin/math/MathLibTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/math/MathLibTest.kt
@@ -1,0 +1,28 @@
+package jp.atcoder.library.kotlin.math
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class MathLibTest {
+    // SafeModTest
+    @Test
+    fun positiveXMod() = assertEquals(1, MathLib.safeMod(1_000_000_008, 1_000_000_007))
+
+    @Test
+    fun negativeXMod() = assertEquals(1, MathLib.safeMod(-1_000_000_006, 1_000_000_007))
+
+    // リファクタ時にバグらせやすい気がするので記載
+    // x % mが0のとき、if (x < 0) (x % m) + m else x % mのようにすると0ではなくmになる
+    @Test
+    fun negativeXModMIsZero() = assertEquals(0, MathLib.safeMod(-2 * 1_000_000_007, 1_000_000_007))
+
+
+
+
+    // PowModTest
+    @Test
+    fun nIsPositive() = assertEquals(73741817, MathLib.powMod(2, 30, 1_000_000_007))
+
+    @Test
+    fun nIszero() = assertEquals(1, MathLib.powMod(100, 0, 1_000_000_007))
+}

--- a/src/test/kotlin/jp/atcoder/library/kotlin/math/MathLibTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/math/MathLibTest.kt
@@ -24,5 +24,5 @@ class MathLibTest {
     fun nIsPositive() = assertEquals(73741817, MathLib.powMod(2, 30, 1_000_000_007))
 
     @Test
-    fun nIszero() = assertEquals(1, MathLib.powMod(100, 0, 1_000_000_007))
+    fun nIsZero() = assertEquals(1, MathLib.powMod(100, 0, 1_000_000_007))
 }


### PR DESCRIPTION
# 概要
[Javaへの移植](https://github.com/NASU41/AtCoderLibraryForJava)にある[MathLib](https://github.com/NASU41/AtCoderLibraryForJava/blob/master/Math/MathLib.java)をコンバートしました。
※safeModとpowMod以外は軽く見ただけだと何をしているのかわからなかったのでconvertのみにしています。

## convertまで対応済みのissue
#9 CRT
#10 FloorSum
invGcd(issueになさそう)

## convertとテストコード記載まで対応済みのissue
#7 powMod
safeMod(issueになさそう)
