### PR TITLE
ModIntへの簡易なテストの追加とリファクタ

### DIFF
--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -15,11 +15,12 @@ class ModIntFactory(private val mod: Int) {
     inner class ModInt(private var rawValue: Int) {
         val mod = this@ModIntFactory.mod
 
-        val value = if (ma is ModArithmetic.ModArithmeticMontgomery) {
-            ma.reduce(rawValue.toLong())
-        } else {
-            rawValue
-        }
+        val value: Int
+            get() = if (ma is ModArithmetic.ModArithmeticMontgomery) {
+                ma.reduce(rawValue.toLong())
+            } else {
+                rawValue
+            }
 
         operator fun plus(mi: ModInt) = ModInt(ma.add(rawValue, mi.rawValue))
         operator fun minus(mi: ModInt) = ModInt(ma.sub(rawValue, mi.rawValue))
@@ -27,7 +28,6 @@ class ModIntFactory(private val mod: Int) {
         operator fun div(mi: ModInt) = ModInt(ma.div(rawValue, mi.rawValue))
         fun inv() = ModInt(ma.inv(rawValue))
         fun pow(b: Long) = ModInt(ma.pow(rawValue, b))
-
 
         fun addAsg(mi: ModInt): ModInt {
             rawValue = ma.add(rawValue, mi.rawValue)

--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -23,14 +23,8 @@ class ModIntFactory(private val mod: Int) {
 
         operator fun plus(mi: ModInt) = ModInt(ma.add(rawValue, mi.rawValue))
         operator fun minus(mi: ModInt) = ModInt(ma.sub(rawValue, mi.rawValue))
-
-        fun mul(mi: ModInt): ModInt {
-            return ModInt(ma.mul(rawValue, mi.rawValue))
-        }
-
-        operator fun div(mi: ModInt): ModInt {
-            return ModInt(ma.div(rawValue, mi.rawValue))
-        }
+        operator fun times(mi: ModInt) = ModInt(ma.mul(rawValue, mi.rawValue))
+        operator fun div(mi: ModInt) = ModInt(ma.div(rawValue, mi.rawValue))
 
         fun inv(): ModInt {
             return ModInt(ma.inv(rawValue))

--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -1,8 +1,13 @@
 package jp.atcoder.library.kotlin.modInt
 
+/** ModInt を生成するためのファクトリ. */
 class ModIntFactory(private val mod: Int) {
     private val ma = ModArithmetic.of(mod)
 
+    /**
+     * ModInt を生成する.
+     * 生成された ModInt は、[value] をファクトリ生成時に指定した mod で割った余りを持つ.
+     */
     fun create(value: Long): ModInt {
         val v = (value % mod).let { if (it < 0) it + mod else it }
         return if (ma is ModArithmetic.ModArithmeticMontgomery) {
@@ -26,24 +31,32 @@ class ModIntFactory(private val mod: Int) {
         operator fun minus(mi: ModInt) = ModInt(ma.sub(rawValue, mi.rawValue))
         operator fun times(mi: ModInt) = ModInt(ma.mul(rawValue, mi.rawValue))
         operator fun div(mi: ModInt) = ModInt(ma.div(rawValue, mi.rawValue))
+
+        /** (this * inv) % mod = 1 を満たすような inv を ModInt として生成して返す. */
         fun inv() = ModInt(ma.inv(rawValue))
+
+        /** (this ^ [b]) % mod の結果を ModInt として生成して返す. */
         fun pow(b: Long) = ModInt(ma.pow(rawValue, b))
 
+        /** this を this + [mi] に変更する */
         fun addAsg(mi: ModInt): ModInt {
             rawValue = ma.add(rawValue, mi.rawValue)
             return this
         }
 
+        /** this を this - [mi] に変更する */
         fun subAsg(mi: ModInt): ModInt {
             rawValue = ma.sub(rawValue, mi.rawValue)
             return this
         }
 
+        /** this を this * [mi] に変更する */
         fun mulAsg(mi: ModInt): ModInt {
             rawValue = ma.mul(rawValue, mi.rawValue)
             return this
         }
 
+        /** this を this / [mi] に変更する */
         fun divAsg(mi: ModInt): ModInt {
             rawValue = ma.div(rawValue, mi.rawValue)
             return this

--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -22,10 +22,7 @@ class ModIntFactory(private val mod: Int) {
         }
 
         operator fun plus(mi: ModInt) = ModInt(ma.add(rawValue, mi.rawValue))
-
-        fun sub(mi: ModInt): ModInt {
-            return ModInt(ma.sub(rawValue, mi.rawValue))
-        }
+        operator fun minus(mi: ModInt) = ModInt(ma.sub(rawValue, mi.rawValue))
 
         fun mul(mi: ModInt): ModInt {
             return ModInt(ma.mul(rawValue, mi.rawValue))

--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -1,15 +1,15 @@
 package jp.atcoder.library.kotlin.modInt
 
-class ModIntFactory(mod: Int) {
-    private val ma: ModArithmetic
-    private val mod: Int
+class ModIntFactory(private val mod: Int) {
+    private val ma = ModArithmetic.of(mod)
 
     fun create(value: Long): ModInt {
-        var v = value
-        if (mod.also { v %= it } < 0) v += mod.toLong()
+        val v = (value % mod).let { if (it < 0) it + mod else it }
         return if (ma is ModArithmetic.ModArithmeticMontgomery) {
             ModInt(ma.generate(v))
-        } else ModInt(v.toInt())
+        } else {
+            ModInt(v.toInt())
+        }
     }
 
     inner class ModInt(private var value: Int) {
@@ -431,10 +431,5 @@ class ModIntFactory(mod: Int) {
                 }
             }
         }
-    }
-
-    init {
-        ma = ModArithmetic.of(mod)
-        this.mod = mod
     }
 }

--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -21,9 +21,7 @@ class ModIntFactory(private val mod: Int) {
             rawValue
         }
 
-        fun add(mi: ModInt): ModInt {
-            return ModInt(ma.add(rawValue, mi.rawValue))
-        }
+        operator fun plus(mi: ModInt) = ModInt(ma.add(rawValue, mi.rawValue))
 
         fun sub(mi: ModInt): ModInt {
             return ModInt(ma.sub(rawValue, mi.rawValue))

--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -25,14 +25,9 @@ class ModIntFactory(private val mod: Int) {
         operator fun minus(mi: ModInt) = ModInt(ma.sub(rawValue, mi.rawValue))
         operator fun times(mi: ModInt) = ModInt(ma.mul(rawValue, mi.rawValue))
         operator fun div(mi: ModInt) = ModInt(ma.div(rawValue, mi.rawValue))
+        fun inv() = ModInt(ma.inv(rawValue))
+        fun pow(b: Long) = ModInt(ma.pow(rawValue, b))
 
-        fun inv(): ModInt {
-            return ModInt(ma.inv(rawValue))
-        }
-
-        fun pow(b: Long): ModInt {
-            return ModInt(ma.pow(rawValue, b))
-        }
 
         fun addAsg(mi: ModInt): ModInt {
             rawValue = ma.add(rawValue, mi.rawValue)

--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -12,74 +12,72 @@ class ModIntFactory(private val mod: Int) {
         }
     }
 
-    inner class ModInt(private var value: Int) {
-        fun mod(): Int {
-            return mod
-        }
+    inner class ModInt(private var rawValue: Int) {
+        val mod = this@ModIntFactory.mod
 
-        fun value(): Int {
-            return if (ma is ModArithmetic.ModArithmeticMontgomery) {
-                ma.reduce(value.toLong())
-            } else value
+        val value = if (ma is ModArithmetic.ModArithmeticMontgomery) {
+            ma.reduce(rawValue.toLong())
+        } else {
+            rawValue
         }
 
         fun add(mi: ModInt): ModInt {
-            return ModInt(ma.add(value, mi.value))
+            return ModInt(ma.add(rawValue, mi.rawValue))
         }
 
         fun sub(mi: ModInt): ModInt {
-            return ModInt(ma.sub(value, mi.value))
+            return ModInt(ma.sub(rawValue, mi.rawValue))
         }
 
         fun mul(mi: ModInt): ModInt {
-            return ModInt(ma.mul(value, mi.value))
+            return ModInt(ma.mul(rawValue, mi.rawValue))
         }
 
         operator fun div(mi: ModInt): ModInt {
-            return ModInt(ma.div(value, mi.value))
+            return ModInt(ma.div(rawValue, mi.rawValue))
         }
 
         fun inv(): ModInt {
-            return ModInt(ma.inv(value))
+            return ModInt(ma.inv(rawValue))
         }
 
         fun pow(b: Long): ModInt {
-            return ModInt(ma.pow(value, b))
+            return ModInt(ma.pow(rawValue, b))
         }
 
         fun addAsg(mi: ModInt): ModInt {
-            value = ma.add(value, mi.value)
+            rawValue = ma.add(rawValue, mi.rawValue)
             return this
         }
 
         fun subAsg(mi: ModInt): ModInt {
-            value = ma.sub(value, mi.value)
+            rawValue = ma.sub(rawValue, mi.rawValue)
             return this
         }
 
         fun mulAsg(mi: ModInt): ModInt {
-            value = ma.mul(value, mi.value)
+            rawValue = ma.mul(rawValue, mi.rawValue)
             return this
         }
 
         fun divAsg(mi: ModInt): ModInt {
-            value = ma.div(value, mi.value)
+            rawValue = ma.div(rawValue, mi.rawValue)
             return this
         }
 
         override fun toString(): String {
-            return value().toString()
+            return value.toString()
         }
 
         override fun equals(other: Any?): Boolean {
             if (other is ModInt) {
-                return mod() == other.mod() && value() == other.value()
+                return mod == other.mod && value == other.value
             }
             return false
         }
 
         override fun hashCode(): Int {
-            return (1 * 37 + mod()) * 37 + value()
+            return (1 * 37 + mod) * 37 + value
         }
     }
 

--- a/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
@@ -100,4 +100,18 @@ class ModIntTest {
         assertThat((a / a).value)
             .isEqualTo(1)
     }
+
+    @Test
+    fun inv() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        assertThat((a * a.inv()).value)
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun pow() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 2)
+        assertThat(a.pow(10).value)
+            .isEqualTo(1024)
+    }
 }

--- a/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
@@ -69,4 +69,12 @@ class ModIntTest {
         assertThat(modFactory1000000007.create(2L * mod1000000007 + 5).value)
             .isEqualTo(5)
     }
+
+    @Test
+    fun plus() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 5)
+        val b = modFactory1000000007.create(2L * mod1000000007 + 10)
+        assertThat((a + b).value)
+            .isEqualTo(15)
+    }
 }

--- a/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
@@ -13,10 +13,10 @@ class FenwickTreeTest {
         val b = factory.create(109)
 
         // Simple multiplication.
-        assertEquals(factory.create(109 * 107), a.mul(b))
+        assertEquals(factory.create(109 * 107), a * b)
 
         // Inverse.
-        val c = a.mul(a.inv())
+        val c = a * a.inv()
         assertEquals(factory.create(1), c)
 
         // Overflow test.
@@ -84,5 +84,20 @@ class ModIntTest {
         val b = modFactory1000000007.create(2L * mod1000000007 + 5)
         assertThat((a - b).value)
             .isEqualTo(5)
+    }
+
+    @Test
+    fun times() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        val b = modFactory1000000007.create(2L * mod1000000007 + 5)
+        assertThat((a * b).value)
+            .isEqualTo(50)
+    }
+
+    @Test
+    fun div() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        assertThat((a / a).value)
+            .isEqualTo(1)
     }
 }

--- a/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
@@ -1,7 +1,8 @@
 package jp.atcoder.library.kotlin.modInt
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 
 class FenwickTreeTest {
@@ -22,3 +23,31 @@ class FenwickTreeTest {
         assertTrue(a.pow(10000).value() > 0)
     }
 }
+
+class ModIntFactoryTest {
+    private val mod1000000007 = 1_000_000_007
+    private lateinit var modFactory1000000007: ModIntFactory
+
+    @Before
+    fun setUp() {
+        // 今の所immutableですが念の為ここでセット
+        modFactory1000000007 = ModIntFactory(mod1000000007)
+    }
+
+    @Test
+    fun createModIntWithPositiveValue() {
+        val modInt = modFactory1000000007.create(2L * mod1000000007 + 5)
+        assertThat(modInt.mod()).isEqualTo(mod1000000007)
+        assertThat(modInt.value()).isEqualTo(5)
+    }
+
+    @Test
+    fun createModIntWithNegativeValue() {
+        assertThat(modFactory1000000007.create(-2L * mod1000000007 + 5L).value())
+            .isEqualTo(5)
+        assertThat(modFactory1000000007.create(-2L * mod1000000007).value())
+            .isEqualTo(0)
+    }
+}
+
+

--- a/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
@@ -77,4 +77,12 @@ class ModIntTest {
         assertThat((a + b).value)
             .isEqualTo(15)
     }
+
+    @Test
+    fun minus() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        val b = modFactory1000000007.create(2L * mod1000000007 + 5)
+        assertThat((a - b).value)
+            .isEqualTo(5)
+    }
 }

--- a/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
@@ -114,4 +114,39 @@ class ModIntTest {
         assertThat(a.pow(10).value)
             .isEqualTo(1024)
     }
+
+    @Test
+    fun addAsg() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        val b = modFactory1000000007.create(2L * mod1000000007 + 5)
+        a.addAsg(b)
+        assertThat(a.value)
+            .isEqualTo(15)
+    }
+
+    @Test
+    fun subAsg() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        val b = modFactory1000000007.create(2L * mod1000000007 + 5)
+        a.subAsg(b)
+        assertThat(a.value)
+            .isEqualTo(5)
+    }
+
+    @Test
+    fun mulAsg() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        val b = modFactory1000000007.create(2L * mod1000000007 + 5)
+        a.mulAsg(b)
+        assertThat(a.value)
+            .isEqualTo(50)
+    }
+
+    @Test
+    fun divAsg() {
+        val a = modFactory1000000007.create(2L * mod1000000007 + 10)
+        a.divAsg(a)
+        assertThat(a.value)
+            .isEqualTo(1)
+    }
 }

--- a/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
+++ b/src/test/kotlin/jp/atcoder/library/kotlin/modInt/modIntTest.kt
@@ -20,7 +20,7 @@ class FenwickTreeTest {
         assertEquals(factory.create(1), c)
 
         // Overflow test.
-        assertTrue(a.pow(10000).value() > 0)
+        assertTrue(a.pow(10000).value > 0)
     }
 }
 
@@ -36,18 +36,37 @@ class ModIntFactoryTest {
 
     @Test
     fun createModIntWithPositiveValue() {
-        val modInt = modFactory1000000007.create(2L * mod1000000007 + 5)
-        assertThat(modInt.mod()).isEqualTo(mod1000000007)
-        assertThat(modInt.value()).isEqualTo(5)
+        assertThat(modFactory1000000007.create(2L * mod1000000007 + 5).value)
+            .isEqualTo(5)
     }
 
     @Test
     fun createModIntWithNegativeValue() {
-        assertThat(modFactory1000000007.create(-2L * mod1000000007 + 5L).value())
+        assertThat(modFactory1000000007.create(-2L * mod1000000007 + 5L).value)
             .isEqualTo(5)
-        assertThat(modFactory1000000007.create(-2L * mod1000000007).value())
+        assertThat(modFactory1000000007.create(-2L * mod1000000007).value)
             .isEqualTo(0)
     }
 }
 
+class ModIntTest {
+    private val mod1000000007 = 1_000_000_007
+    private lateinit var modFactory1000000007: ModIntFactory
 
+    @Before
+    fun setUp() {
+        modFactory1000000007 = ModIntFactory(mod1000000007)
+    }
+
+    @Test
+    fun haveMod() {
+        assertThat(modFactory1000000007.create(2L * mod1000000007).mod)
+            .isEqualTo(mod1000000007)
+    }
+
+    @Test
+    fun haveValue() {
+        assertThat(modFactory1000000007.create(2L * mod1000000007 + 5).value)
+            .isEqualTo(5)
+    }
+}


### PR DESCRIPTION
# 概要

- #13 ModIntにあるpublicメソッドのリファクタ(主にoperatorへの書き換え)と簡易なテストを追加してみました。
※下記のように実装が複数ありますが、テストはModArithmetic1000000007で挫折...
```kotlin
companion object {
    fun of(mod: Int): ModArithmetic {
        return when {
            mod <= 0 -> throw IllegalArgumentException()
            mod == 1 -> ModArithmetic1()
            mod == 2 -> ModArithmetic2()
            mod == 998244353 -> ModArithmetic998244353()
            mod == 1000000007 -> ModArithmetic1000000007()
            mod and 1 == 1 -> ModArithmeticMontgomery(mod)
            else -> ModArithmeticBarrett(mod)
        }
    }
}
```

変更が多くなってしまったので、コミット毎に確認いただいくほうが楽だと思います。

#  変更したほうが良さそうな部分
hashCodeとequalsはIntelliJで再生成したほうが良さそう（試しにやってみたらhashCodeの実装が少し違かったので..）