### PR TITLE
KDocからドキュメントを生成するためにdokkaを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - ライセンスは本家を踏襲し、[CC0ライセンス](LICENSE)です。必ずよく読んでご利用下さい。
 
 # Documents
-- [docs/ac-library-kt](./docs/ac-library-kt)  
+- [docs/ac-library-kt/index.md](./docs/ac-library-kt/index.md)  
 ※ソースコードに記載されているKDocから自動生成したものです。
 
 # Requirement

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
     - convertする都合上、上記の目標はなしとしました。
 - ライセンスは本家を踏襲し、[CC0ライセンス](LICENSE)です。必ずよく読んでご利用下さい。
 
+# Documents
+- [docs/ac-library-kt](./docs/ac-library-kt)  
+※ソースコードに記載されているKDocから自動生成したものです。
+
 # Requirement
 
 - IDE

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.71'
+    id 'org.jetbrains.dokka' version "1.4.0-rc"
 }
 
 group 'atcoder-kotlin-trying'
@@ -32,4 +33,8 @@ compileTestKotlin {
 
 test {
     useJUnitPlatform()
+}
+
+dokkaGfm {
+    outputDirectory = "$projectDir/docs"
 }

--- a/docs/ac-library-kt/index.md
+++ b/docs/ac-library-kt/index.md
@@ -1,0 +1,24 @@
+//[ac-library-kt](index.md)
+
+
+
+# ac-library-kt  
+
+
+## Packages  
+  
+|  Name|  Summary| 
+|---|---|
+| [jp.atcoder.library.kotlin.convolution](jp.atcoder.library.kotlin.convolution/index.md) | 
+| [jp.atcoder.library.kotlin.dsu](jp.atcoder.library.kotlin.dsu/index.md) | 
+| [jp.atcoder.library.kotlin.fenwickTree](jp.atcoder.library.kotlin.fenwickTree/index.md) | 
+| [jp.atcoder.library.kotlin.lazySegTree](jp.atcoder.library.kotlin.lazySegTree.md) | 
+| [jp.atcoder.library.kotlin.math](jp.atcoder.library.kotlin.math.md) | 
+| [jp.atcoder.library.kotlin.maxFlow](jp.atcoder.library.kotlin.maxFlow/index.md) | 
+| [jp.atcoder.library.kotlin.minCostFlow](jp.atcoder.library.kotlin.minCostFlow/index.md) | 
+| [jp.atcoder.library.kotlin.modInt](jp.atcoder.library.kotlin.modInt/index.md) | 
+| [jp.atcoder.library.kotlin.scc](jp.atcoder.library.kotlin.scc/index.md) | 
+| [jp.atcoder.library.kotlin.segTree](jp.atcoder.library.kotlin.segTree/index.md) | 
+| [jp.atcoder.library.kotlin.stringAlgorithm](jp.atcoder.library.kotlin.stringAlgorithm/index.md) | 
+| [jp.atcoder.library.kotlin.twoSAT](jp.atcoder.library.kotlin.twoSAT/index.md) | 
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.convolution](../index.md)/[Convolution](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)()  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/convolution-l-l.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/convolution-l-l.md
@@ -1,0 +1,32 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.convolution](../index.md)/[Convolution](index.md)/[convolutionLL](convolution-l-l.md)
+
+
+
+# convolutionLL  
+[jvm]  
+Brief description  
+Convolution.  
+  
+
+
+#### Return  
+Answer.  
+  
+
+
+## Parameters  
+  
+jvm  
+  
+|  Name|  Summary| 
+|---|---|
+| a| Target array 1.
+| b| Target array 2.
+| mod| Any mod.
+  
+  
+Content  
+fun [convolutionLL](convolution-l-l.md)(a: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), b: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/convolution-naive.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/convolution-naive.md
@@ -1,0 +1,32 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.convolution](../index.md)/[Convolution](index.md)/[convolutionNaive](convolution-naive.md)
+
+
+
+# convolutionNaive  
+[jvm]  
+Brief description  
+Naive convolution. (Complexity is O(N^2)!!)  
+  
+
+
+#### Return  
+Answer.  
+  
+
+
+## Parameters  
+  
+jvm  
+  
+|  Name|  Summary| 
+|---|---|
+| a| Target array 1.
+| b| Target array 2.
+| mod| Mod.
+  
+  
+Content  
+fun [convolutionNaive](convolution-naive.md)(a: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), b: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/convolution.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/convolution.md
@@ -1,0 +1,57 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.convolution](../index.md)/[Convolution](index.md)/[convolution](convolution.md)
+
+
+
+# convolution  
+[jvm]  
+Brief description  
+Convolution.  
+  
+
+
+#### Return  
+Answer.  
+  
+
+
+## Parameters  
+  
+jvm  
+  
+|  Name|  Summary| 
+|---|---|
+| a| Target array 1.
+| b| Target array 2.
+| mod| NTT Prime.
+  
+  
+Content  
+fun [convolution](convolution.md)(a: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), b: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  
+
+
+[jvm]  
+Brief description  
+Convolution by ModInt.  
+  
+
+
+#### Return  
+Answer.  
+  
+
+
+## Parameters  
+  
+jvm  
+  
+|  Name|  Summary| 
+|---|---|
+| a| Target array 1.
+| b| Target array 2.
+  
+  
+Content  
+fun [convolution](convolution.md)(a: [List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)<[ModIntFactory.ModInt](../../jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md)>, b: [List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)<[ModIntFactory.ModInt](../../jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md)>): [List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)<[ModIntFactory.ModInt](../../jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md)>  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/-convolution/index.md
@@ -1,0 +1,28 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.convolution](../index.md)/[Convolution](index.md)
+
+
+
+# Convolution  
+ [jvm] Convolution.convert from [AtCoderLibraryForJava - Convolution](https://github.com/NASU41/AtCoderLibraryForJava/blob/a7e73af20f0553b9d9c4a2e7c4194af817b12485/Convolution/Convolution.java#L10)  
+  
+class [Convolution](index.md)   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)()   <br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [convolution](convolution.md)| [jvm]  <br>Brief description  <br>Convolution.  <br>Content  <br>fun [convolution](convolution.md)(a: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), b: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  <br><br><br>[jvm]  <br>Brief description  <br>Convolution by ModInt.  <br>Content  <br>fun [convolution](convolution.md)(a: [List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)<[ModIntFactory.ModInt](../../jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md)>, b: [List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)<[ModIntFactory.ModInt](../../jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md)>): [List](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/index.html)<[ModIntFactory.ModInt](../../jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md)>  <br><br><br>
+| [convolutionLL](convolution-l-l.md)| [jvm]  <br>Brief description  <br>Convolution.  <br>Content  <br>fun [convolutionLL](convolution-l-l.md)(a: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), b: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  <br><br><br>
+| [convolutionNaive](convolution-naive.md)| [jvm]  <br>Brief description  <br>Naive convolution. (Complexity is O(N^2)!!)  <br>Content  <br>fun [convolutionNaive](convolution-naive.md)(a: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), b: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html), mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.convolution/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.convolution](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.convolution  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [Convolution](-convolution/index.md)| [jvm]  <br>Brief description  <br>Convolution.convert from [AtCoderLibraryForJava - Convolution](https://github.com/NASU41/AtCoderLibraryForJava/blob/a7e73af20f0553b9d9c4a2e7c4194af817b12485/Convolution/Convolution.java#L10)  <br>Content  <br>class [Convolution](-convolution/index.md)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.dsu](../index.md)/[DSU](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/groups.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/groups.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.dsu](../index.md)/[DSU](index.md)/[groups](groups.md)
+
+
+
+# groups  
+[jvm]  
+Brief description  
+Group by leader.  
+  
+  
+Content  
+fun [groups](groups.md)(): [ArrayList](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html)<[ArrayList](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html)<[Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)>>  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/index.md
@@ -1,0 +1,30 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.dsu](../index.md)/[DSU](index.md)
+
+
+
+# DSU  
+ [jvm] Disjoint set union.convert from [AtCoderLibraryForJava - DSU](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/DSU/DSU.java)  
+  
+class [DSU](index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   <br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [groups](groups.md)| [jvm]  <br>Brief description  <br>Group by leader.  <br>Content  <br>fun [groups](groups.md)(): [ArrayList](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html)<[ArrayList](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html)<[Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)>>  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [leader](leader.md)| [jvm]  <br>Brief description  <br>Get its leader node.  <br>Content  <br>fun [leader](leader.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [merge](merge.md)| [jvm]  <br>Brief description  <br>Merge nodes.  <br>Content  <br>fun [merge](merge.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), b: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [same](same.md)| [jvm]  <br>Brief description  <br>True if two nodes are connected.  <br>Content  <br>fun [same](same.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), b: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [size](size.md)| [jvm]  <br>Brief description  <br>A group's size.  <br>Content  <br>fun [size](size.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/leader.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/leader.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.dsu](../index.md)/[DSU](index.md)/[leader](leader.md)
+
+
+
+# leader  
+[jvm]  
+Brief description  
+Get its leader node.  
+  
+  
+Content  
+fun [leader](leader.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/merge.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/merge.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.dsu](../index.md)/[DSU](index.md)/[merge](merge.md)
+
+
+
+# merge  
+[jvm]  
+Brief description  
+Merge nodes.  
+  
+  
+Content  
+fun [merge](merge.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), b: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/same.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/same.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.dsu](../index.md)/[DSU](index.md)/[same](same.md)
+
+
+
+# same  
+[jvm]  
+Brief description  
+True if two nodes are connected.  
+  
+  
+Content  
+fun [same](same.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), b: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/size.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/-d-s-u/size.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.dsu](../index.md)/[DSU](index.md)/[size](size.md)
+
+
+
+# size  
+[jvm]  
+Brief description  
+A group's size.  
+  
+  
+Content  
+fun [size](size.md)(a: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.dsu/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.dsu](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.dsu  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [DSU](-d-s-u/index.md)| [jvm]  <br>Brief description  <br>Disjoint set union.convert from [AtCoderLibraryForJava - DSU](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/DSU/DSU.java)  <br>Content  <br>class [DSU](-d-s-u/index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/-init-.md
@@ -1,0 +1,20 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.fenwickTree](../index.md)/[FenwickTree](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Brief description  
+Fenwick tree constructor.  
+  
+  
+Content  
+fun [<init>](-init-.md)(data: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html))  
+
+
+[jvm]  
+Content  
+fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/add.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/add.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.fenwickTree](../index.md)/[FenwickTree](index.md)/[add](add.md)
+
+
+
+# add  
+[jvm]  
+Brief description  
+Add value x to p.  
+  
+  
+Content  
+fun [add](add.md)(p: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), x: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/index.md
@@ -1,0 +1,28 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.fenwickTree](../index.md)/[FenwickTree](index.md)
+
+
+
+# FenwickTree  
+ [jvm] Fenwick tree(0-indexed).convert from [AtCoderLibraryForJava - FenwickTree](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/FenwickTree/FenwickTree.java)  
+  
+class [FenwickTree](index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] Fenwick tree constructor.fun [<init>](-init-.md)(data: [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html))   <br>
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   <br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [add](add.md)| [jvm]  <br>Brief description  <br>Add value x to p.  <br>Content  <br>fun [add](add.md)(p: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), x: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html))  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [sum](sum.md)| [jvm]  <br>Brief description  <br>Calc sum [l, r]([l, r]).  <br>Content  <br>fun [sum](sum.md)(l: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), r: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/sum.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/-fenwick-tree/sum.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.fenwickTree](../index.md)/[FenwickTree](index.md)/[sum](sum.md)
+
+
+
+# sum  
+[jvm]  
+Brief description  
+Calc sum [l, r]([l, r]).  
+  
+  
+Content  
+fun [sum](sum.md)(l: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), r: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.fenwickTree/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.fenwickTree](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.fenwickTree  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [FenwickTree](-fenwick-tree/index.md)| [jvm]  <br>Brief description  <br>Fenwick tree(0-indexed).convert from [AtCoderLibraryForJava - FenwickTree](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/FenwickTree/FenwickTree.java)  <br>Content  <br>class [FenwickTree](-fenwick-tree/index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.lazySegTree.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.lazySegTree.md
@@ -1,0 +1,6 @@
+//[ac-library-kt](index.md)/[jp.atcoder.library.kotlin.lazySegTree](jp.atcoder.library.kotlin.lazySegTree.md)
+
+
+
+# Package jp.atcoder.library.kotlin.lazySegTree  
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.math.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.math.md
@@ -1,0 +1,6 @@
+//[ac-library-kt](index.md)/[jp.atcoder.library.kotlin.math](jp.atcoder.library.kotlin.math.md)
+
+
+
+# Package jp.atcoder.library.kotlin.math  
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/-cap-edge/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/-cap-edge/index.md
@@ -1,0 +1,26 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../../index.md)/[MaxFlow](../index.md)/[CapEdge](index.md)
+
+
+
+# CapEdge  
+ [jvm] inner class [CapEdge](index.md)   
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+
+
+## Properties  
+  
+|  Name|  Summary| 
+|---|---|
+| [cap](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/cap/#/PointingToDeclaration/)|  [jvm] var [cap](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/cap/#/PointingToDeclaration/): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)   <br>
+| [from](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/from/#/PointingToDeclaration/)|  [jvm] val [from](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/from/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+| [rev](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/rev/#/PointingToDeclaration/)|  [jvm] val [rev](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/rev/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+| [to](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/to/#/PointingToDeclaration/)|  [jvm] val [to](index.md#jp.atcoder.library.kotlin.maxFlow/MaxFlow.CapEdge/to/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/-companion/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/-companion/index.md
@@ -1,0 +1,16 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../../index.md)/[MaxFlow](../index.md)/[Companion](index.md)
+
+
+
+# Companion  
+ [jvm] object [Companion](index.md)   
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/add-edge.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/add-edge.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[addEdge](add-edge.md)
+
+
+
+# addEdge  
+[jvm]  
+Content  
+fun [addEdge](add-edge.md)(from: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), to: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), cap: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/change-edge.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/change-edge.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[changeEdge](change-edge.md)
+
+
+
+# changeEdge  
+[jvm]  
+Content  
+fun [changeEdge](change-edge.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), newCap: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html), newFlow: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/flow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/flow.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[flow](flow.md)
+
+
+
+# flow  
+[jvm]  
+Content  
+fun [flow](flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/ford-fulkerson-flow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/ford-fulkerson-flow.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[fordFulkersonFlow](ford-fulkerson-flow.md)
+
+
+
+# fordFulkersonFlow  
+[jvm]  
+Content  
+fun [fordFulkersonFlow](ford-fulkerson-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/ford-fulkerson-max-flow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/ford-fulkerson-max-flow.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[fordFulkersonMaxFlow](ford-fulkerson-max-flow.md)
+
+
+
+# fordFulkersonMaxFlow  
+[jvm]  
+Content  
+fun [fordFulkersonMaxFlow](ford-fulkerson-max-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/get-edge.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/get-edge.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[getEdge](get-edge.md)
+
+
+
+# getEdge  
+[jvm]  
+Content  
+fun [getEdge](get-edge.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [MaxFlow.CapEdge](-cap-edge/index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/index.md
@@ -1,0 +1,41 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)
+
+
+
+# MaxFlow  
+ [jvm] convert from [AtCoderLibraryForJava - MaxFlow](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/MaxFlow/MaxFlow.java)  
+  
+class [MaxFlow](index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   <br>
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [CapEdge](-cap-edge/index.md)| [jvm]  <br>Content  <br>inner class [CapEdge](-cap-edge/index.md)  <br><br><br>
+| [Companion](-companion/index.md)| [jvm]  <br>Content  <br>object [Companion](-companion/index.md)  <br><br><br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [addEdge](add-edge.md)| [jvm]  <br>Content  <br>fun [addEdge](add-edge.md)(from: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), to: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), cap: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [changeEdge](change-edge.md)| [jvm]  <br>Content  <br>fun [changeEdge](change-edge.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), newCap: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html), newFlow: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html))  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [flow](flow.md)| [jvm]  <br>Content  <br>fun [flow](flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  <br><br><br>
+| [fordFulkersonFlow](ford-fulkerson-flow.md)| [jvm]  <br>Content  <br>fun [fordFulkersonFlow](ford-fulkerson-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  <br><br><br>
+| [fordFulkersonMaxFlow](ford-fulkerson-max-flow.md)| [jvm]  <br>Content  <br>fun [fordFulkersonMaxFlow](ford-fulkerson-max-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  <br><br><br>
+| [getEdge](get-edge.md)| [jvm]  <br>Content  <br>fun [getEdge](get-edge.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [MaxFlow.CapEdge](-cap-edge/index.md)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [maxFlow](max-flow.md)| [jvm]  <br>Content  <br>fun [maxFlow](max-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  <br><br><br>
+| [minCut](min-cut.md)| [jvm]  <br>Content  <br>fun [minCut](min-cut.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [BooleanArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean-array/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/max-flow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/max-flow.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[maxFlow](max-flow.md)
+
+
+
+# maxFlow  
+[jvm]  
+Content  
+fun [maxFlow](max-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/min-cut.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/-max-flow/min-cut.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.maxFlow](../index.md)/[MaxFlow](index.md)/[minCut](min-cut.md)
+
+
+
+# minCut  
+[jvm]  
+Content  
+fun [minCut](min-cut.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [BooleanArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.maxFlow/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.maxFlow](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.maxFlow  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [MaxFlow](-max-flow/index.md)| [jvm]  <br>Brief description  <br>convert from [AtCoderLibraryForJava - MaxFlow](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/MaxFlow/MaxFlow.java)  <br>Content  <br>class [MaxFlow](-max-flow/index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/-companion/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/-companion/index.md
@@ -1,0 +1,16 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../../index.md)/[MinCostFlow](../index.md)/[Companion](index.md)
+
+
+
+# Companion  
+ [jvm] object [Companion](index.md)   
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/-weighted-cap-edge/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/-weighted-cap-edge/index.md
@@ -1,0 +1,27 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../../index.md)/[MinCostFlow](../index.md)/[WeightedCapEdge](index.md)
+
+
+
+# WeightedCapEdge  
+ [jvm] inner class [WeightedCapEdge](index.md)   
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+
+
+## Properties  
+  
+|  Name|  Summary| 
+|---|---|
+| [cap](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/cap/#/PointingToDeclaration/)|  [jvm] var [cap](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/cap/#/PointingToDeclaration/): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)   <br>
+| [cost](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/cost/#/PointingToDeclaration/)|  [jvm] var [cost](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/cost/#/PointingToDeclaration/): [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)   <br>
+| [from](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/from/#/PointingToDeclaration/)|  [jvm] val [from](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/from/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+| [rev](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/rev/#/PointingToDeclaration/)|  [jvm] val [rev](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/rev/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+| [to](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/to/#/PointingToDeclaration/)|  [jvm] val [to](index.md#jp.atcoder.library.kotlin.minCostFlow/MinCostFlow.WeightedCapEdge/to/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/add-edge.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/add-edge.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)/[addEdge](add-edge.md)
+
+
+
+# addEdge  
+[jvm]  
+Content  
+fun [addEdge](add-edge.md)(from: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), to: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), cap: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html), cost: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/clear-flow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/clear-flow.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)/[clearFlow](clear-flow.md)
+
+
+
+# clearFlow  
+[jvm]  
+Content  
+fun [clearFlow](clear-flow.md)()  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/get-edge.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/get-edge.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)/[getEdge](get-edge.md)
+
+
+
+# getEdge  
+[jvm]  
+Content  
+fun [getEdge](get-edge.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [MinCostFlow.WeightedCapEdge](-weighted-cap-edge/index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/index.md
@@ -1,0 +1,39 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)
+
+
+
+# MinCostFlow  
+ [jvm] convert from [AtCoderLibraryForJava - MinCostFlow](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/MinCostFlow/MinCostFlow.java)  
+  
+class [MinCostFlow](index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   <br>
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [Companion](-companion/index.md)| [jvm]  <br>Content  <br>object [Companion](-companion/index.md)  <br><br><br>
+| [WeightedCapEdge](-weighted-cap-edge/index.md)| [jvm]  <br>Content  <br>inner class [WeightedCapEdge](-weighted-cap-edge/index.md)  <br><br><br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [addEdge](add-edge.md)| [jvm]  <br>Content  <br>fun [addEdge](add-edge.md)(from: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), to: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), cap: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html), cost: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [clearFlow](clear-flow.md)| [jvm]  <br>Content  <br>fun [clearFlow](clear-flow.md)()  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [getEdge](get-edge.md)| [jvm]  <br>Content  <br>fun [getEdge](get-edge.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [MinCostFlow.WeightedCapEdge](-weighted-cap-edge/index.md)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [minCostFlow](min-cost-flow.md)| [jvm]  <br>Content  <br>fun [minCostFlow](min-cost-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  <br><br><br>
+| [minCostMaxFlow](min-cost-max-flow.md)| [jvm]  <br>Content  <br>fun [minCostMaxFlow](min-cost-max-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  <br><br><br>
+| [minCostSlope](min-cost-slope.md)| [jvm]  <br>Content  <br>@[JvmOverloads](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-overloads/index.html)()  <br>  <br>fun [minCostSlope](min-cost-slope.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [ArrayList](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html)<[LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)>  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/min-cost-flow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/min-cost-flow.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)/[minCostFlow](min-cost-flow.md)
+
+
+
+# minCostFlow  
+[jvm]  
+Content  
+fun [minCostFlow](min-cost-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/min-cost-max-flow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/min-cost-max-flow.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)/[minCostMaxFlow](min-cost-max-flow.md)
+
+
+
+# minCostMaxFlow  
+[jvm]  
+Content  
+fun [minCostMaxFlow](min-cost-max-flow.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/min-cost-slope.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/-min-cost-flow/min-cost-slope.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.minCostFlow](../index.md)/[MinCostFlow](index.md)/[minCostSlope](min-cost-slope.md)
+
+
+
+# minCostSlope  
+[jvm]  
+Content  
+@[JvmOverloads](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-overloads/index.html)()  
+  
+fun [minCostSlope](min-cost-slope.md)(s: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), t: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), flowLimit: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [ArrayList](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html)<[LongArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long-array/index.html)>  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.minCostFlow/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.minCostFlow](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.minCostFlow  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [MinCostFlow](-min-cost-flow/index.md)| [jvm]  <br>Brief description  <br>convert from [AtCoderLibraryForJava - MinCostFlow](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/MinCostFlow/MinCostFlow.java)  <br>Content  <br>class [MinCostFlow](-min-cost-flow/index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.modInt](../index.md)/[ModIntFactory](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)(mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)(rawValue: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/add-asg.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/add-asg.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[addAsg](add-asg.md)
+
+
+
+# addAsg  
+[jvm]  
+Brief description  
+this を this + [mi]() に変更する  
+  
+  
+Content  
+fun [addAsg](add-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/div-asg.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/div-asg.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[divAsg](div-asg.md)
+
+
+
+# divAsg  
+[jvm]  
+Brief description  
+this を this / [mi]() に変更する  
+  
+  
+Content  
+fun [divAsg](div-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/div.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/div.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[div](div.md)
+
+
+
+# div  
+[jvm]  
+Content  
+operator fun [div](div.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/equals.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/equals.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[equals](equals.md)
+
+
+
+# equals  
+[jvm]  
+Content  
+open operator override fun [equals](equals.md)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/hash-code.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/hash-code.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[hashCode](hash-code.md)
+
+
+
+# hashCode  
+[jvm]  
+Content  
+open override fun [hashCode](hash-code.md)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/index.md
@@ -1,0 +1,34 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)
+
+
+
+# ModInt  
+ [jvm] inner class [ModInt](index.md)(**rawValue**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [addAsg](add-asg.md)| [jvm]  <br>Brief description  <br>this を this + [mi]() に変更する  <br>Content  <br>fun [addAsg](add-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [div](div.md)| [jvm]  <br>Content  <br>operator fun [div](div.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [divAsg](div-asg.md)| [jvm]  <br>Brief description  <br>this を this / [mi]() に変更する  <br>Content  <br>fun [divAsg](div-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [equals](equals.md)| [jvm]  <br>Content  <br>open operator override fun [equals](equals.md)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](hash-code.md)| [jvm]  <br>Content  <br>open override fun [hashCode](hash-code.md)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [inv](inv.md)| [jvm]  <br>Brief description  <br>(this * inv) % mod = 1 を満たすような inv を ModInt として生成して返す.  <br>Content  <br>fun [inv](inv.md)(): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [minus](minus.md)| [jvm]  <br>Content  <br>operator fun [minus](minus.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [mulAsg](mul-asg.md)| [jvm]  <br>Brief description  <br>this を this * [mi]() に変更する  <br>Content  <br>fun [mulAsg](mul-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [plus](plus.md)| [jvm]  <br>Content  <br>operator fun [plus](plus.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [pow](pow.md)| [jvm]  <br>Brief description  <br>(this ^ [b]()) % mod の結果を ModInt として生成して返す.  <br>Content  <br>fun [pow](pow.md)(b: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [subAsg](sub-asg.md)| [jvm]  <br>Brief description  <br>this を this - [mi]() に変更する  <br>Content  <br>fun [subAsg](sub-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [times](times.md)| [jvm]  <br>Content  <br>operator fun [times](times.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  <br><br><br>
+| [toString](to-string.md)| [jvm]  <br>Content  <br>open override fun [toString](to-string.md)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+
+
+## Properties  
+  
+|  Name|  Summary| 
+|---|---|
+| [mod](index.md#jp.atcoder.library.kotlin.modInt/ModIntFactory.ModInt/mod/#/PointingToDeclaration/)|  [jvm] val [mod](index.md#jp.atcoder.library.kotlin.modInt/ModIntFactory.ModInt/mod/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+| [value](index.md#jp.atcoder.library.kotlin.modInt/ModIntFactory.ModInt/value/#/PointingToDeclaration/)|  [jvm] val [value](index.md#jp.atcoder.library.kotlin.modInt/ModIntFactory.ModInt/value/#/PointingToDeclaration/): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)   <br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/inv.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/inv.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[inv](inv.md)
+
+
+
+# inv  
+[jvm]  
+Brief description  
+(this * inv) % mod = 1 を満たすような inv を ModInt として生成して返す.  
+  
+  
+Content  
+fun [inv](inv.md)(): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/minus.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/minus.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[minus](minus.md)
+
+
+
+# minus  
+[jvm]  
+Content  
+operator fun [minus](minus.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/mul-asg.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/mul-asg.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[mulAsg](mul-asg.md)
+
+
+
+# mulAsg  
+[jvm]  
+Brief description  
+this を this * [mi]() に変更する  
+  
+  
+Content  
+fun [mulAsg](mul-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/plus.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/plus.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[plus](plus.md)
+
+
+
+# plus  
+[jvm]  
+Content  
+operator fun [plus](plus.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/pow.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/pow.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[pow](pow.md)
+
+
+
+# pow  
+[jvm]  
+Brief description  
+(this ^ [b]()) % mod の結果を ModInt として生成して返す.  
+  
+  
+Content  
+fun [pow](pow.md)(b: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/sub-asg.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/sub-asg.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[subAsg](sub-asg.md)
+
+
+
+# subAsg  
+[jvm]  
+Brief description  
+this を this - [mi]() に変更する  
+  
+  
+Content  
+fun [subAsg](sub-asg.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/times.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/times.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[times](times.md)
+
+
+
+# times  
+[jvm]  
+Content  
+operator fun [times](times.md)(mi: [ModIntFactory.ModInt](index.md)): [ModIntFactory.ModInt](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/to-string.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/-mod-int/to-string.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../../index.md)/[jp.atcoder.library.kotlin.modInt](../../index.md)/[ModIntFactory](../index.md)/[ModInt](index.md)/[toString](to-string.md)
+
+
+
+# toString  
+[jvm]  
+Content  
+open override fun [toString](to-string.md)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/create.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/create.md
@@ -1,0 +1,15 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.modInt](../index.md)/[ModIntFactory](index.md)/[create](create.md)
+
+
+
+# create  
+[jvm]  
+Brief description  
+ModInt を生成する. 生成された ModInt は、[value]() をファクトリ生成時に指定した mod で割った余りを持つ.  
+  
+  
+Content  
+fun [create](create.md)(value: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [ModIntFactory.ModInt](-mod-int/index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/-mod-int-factory/index.md
@@ -1,0 +1,33 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.modInt](../index.md)/[ModIntFactory](index.md)
+
+
+
+# ModIntFactory  
+ [jvm] ModInt を生成するためのファクトリ.  
+  
+class [ModIntFactory](index.md)(**mod**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)(mod: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   <br>
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [ModInt](-mod-int/index.md)| [jvm]  <br>Content  <br>inner class [ModInt](-mod-int/index.md)(**rawValue**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [create](create.md)| [jvm]  <br>Brief description  <br>ModInt を生成する. 生成された ModInt は、[value]() をファクトリ生成時に指定した mod で割った余りを持つ.  <br>Content  <br>fun [create](create.md)(value: [Long](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long/index.html)): [ModIntFactory.ModInt](-mod-int/index.md)  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.modInt/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.modInt](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.modInt  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [ModIntFactory](-mod-int-factory/index.md)| [jvm]  <br>Brief description  <br>ModInt を生成するためのファクトリ.  <br>Content  <br>class [ModIntFactory](-mod-int-factory/index.md)(**mod**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.scc](../index.md)/[SCC](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/add-edge.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/add-edge.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.scc](../index.md)/[SCC](index.md)/[addEdge](add-edge.md)
+
+
+
+# addEdge  
+[jvm]  
+Content  
+fun [addEdge](add-edge.md)(from: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), to: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/build.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/build.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.scc](../index.md)/[SCC](index.md)/[build](build.md)
+
+
+
+# build  
+[jvm]  
+Content  
+fun [build](build.md)(): [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-array/index.html)<[IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)>  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/id.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/id.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.scc](../index.md)/[SCC](index.md)/[id](id.md)
+
+
+
+# id  
+[jvm]  
+Content  
+fun [id](id.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/-s-c-c/index.md
@@ -1,0 +1,28 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.scc](../index.md)/[SCC](index.md)
+
+
+
+# SCC  
+ [jvm] convert from [AtCoderLibraryForJava - SCC](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/SCC/SCC.java)  
+  
+class [SCC](index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   <br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [addEdge](add-edge.md)| [jvm]  <br>Content  <br>fun [addEdge](add-edge.md)(from: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), to: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+| [build](build.md)| [jvm]  <br>Content  <br>fun [build](build.md)(): [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-array/index.html)<[IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)>  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [id](id.md)| [jvm]  <br>Content  <br>fun [id](id.md)(i: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.scc/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.scc](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.scc  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [SCC](-s-c-c/index.md)| [jvm]  <br>Brief description  <br>convert from [AtCoderLibraryForJava - SCC](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/SCC/SCC.java)  <br>Content  <br>class [SCC](-s-c-c/index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/-init-.md
@@ -1,0 +1,12 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun <[S](index.md) : [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?> [<init>](-init-.md)(dat: [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-array/index.html)<[S](index.md)>, op: [BinaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html)<[S](index.md)>, e: [S](index.md))  
+fun <[S](index.md) : [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?> [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), op: [BinaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html)<[S](index.md)>, e: [S](index.md))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/all-prod.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/all-prod.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)/[allProd](all-prod.md)
+
+
+
+# allProd  
+[jvm]  
+Content  
+fun [allProd](all-prod.md)(): [S](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/get.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/get.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)/[get](get.md)
+
+
+
+# get  
+[jvm]  
+Content  
+operator fun [get](get.md)(p: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [S](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/index.md
@@ -1,0 +1,32 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)
+
+
+
+# SegTree  
+ [jvm] Segment tree(0-indexed)convert from [AtCoderLibraryForJava - SegTree](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/SegTree/SegTree.java)  
+  
+class [SegTree](index.md)<[S](index.md) : [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?> (**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html),**op**: [BinaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html)<[S](index.md)>,**e**: [S](index.md))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun <[S](index.md) : [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?> [<init>](-init-.md)(dat: [Array](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-array/index.html)<[S](index.md)>, op: [BinaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html)<[S](index.md)>, e: [S](index.md))   <br>
+| [<init>](-init-.md)|  [jvm] fun <[S](index.md) : [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?> [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), op: [BinaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html)<[S](index.md)>, e: [S](index.md))   <br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [allProd](all-prod.md)| [jvm]  <br>Content  <br>fun [allProd](all-prod.md)(): [S](index.md)  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [get](get.md)| [jvm]  <br>Content  <br>operator fun [get](get.md)(p: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [S](index.md)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [maxRight](max-right.md)| [jvm]  <br>Content  <br>fun [maxRight](max-right.md)(l: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Predicate](https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html)<[S](index.md)>): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [minLeft](min-left.md)| [jvm]  <br>Content  <br>fun [minLeft](min-left.md)(r: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Predicate](https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html)<[S](index.md)>): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [prod](prod.md)| [jvm]  <br>Content  <br>fun [prod](prod.md)(l: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), r: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [S](index.md)  <br><br><br>
+| [set](set.md)| [jvm]  <br>Content  <br>operator fun [set](set.md)(p: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), x: [S](index.md))  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/max-right.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/max-right.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)/[maxRight](max-right.md)
+
+
+
+# maxRight  
+[jvm]  
+Content  
+fun [maxRight](max-right.md)(l: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Predicate](https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html)<[S](index.md)>): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/min-left.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/min-left.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)/[minLeft](min-left.md)
+
+
+
+# minLeft  
+[jvm]  
+Content  
+fun [minLeft](min-left.md)(r: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Predicate](https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html)<[S](index.md)>): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/prod.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/prod.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)/[prod](prod.md)
+
+
+
+# prod  
+[jvm]  
+Content  
+fun [prod](prod.md)(l: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), r: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [S](index.md)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/set.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/-seg-tree/set.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.segTree](../index.md)/[SegTree](index.md)/[set](set.md)
+
+
+
+# set  
+[jvm]  
+Content  
+operator fun [set](set.md)(p: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), x: [S](index.md))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.segTree/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.segTree](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.segTree  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [SegTree](-seg-tree/index.md)| [jvm]  <br>Brief description  <br>Segment tree(0-indexed)convert from [AtCoderLibraryForJava - SegTree](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/SegTree/SegTree.java)  <br>Content  <br>class [SegTree](-seg-tree/index.md)<[S](-seg-tree/index.md) : [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?> (**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html),**op**: [BinaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html)<[S](-seg-tree/index.md)>,**e**: [S](-seg-tree/index.md))  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/index.md
@@ -1,0 +1,19 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.stringAlgorithm](../index.md)/[StringAlgorithm](index.md)
+
+
+
+# StringAlgorithm  
+ [jvm] object [StringAlgorithm](index.md)   
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [lcpArray](lcp-array.md)| [jvm]  <br>Content  <br>fun [lcpArray](lcp-array.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html), sa: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br>fun [lcpArray](lcp-array.md)(s: [CharArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-array/index.html), sa: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br>fun [lcpArray](lcp-array.md)(s: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html), sa: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br><br><br>
+| [suffixArray](suffix-array.md)| [jvm]  <br>Content  <br>fun [suffixArray](suffix-array.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html), upper: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br>fun [suffixArray](suffix-array.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br>fun [suffixArray](suffix-array.md)(s: [CharArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br>fun [suffixArray](suffix-array.md)(s: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+| [zAlgorithm](z-algorithm.md)| [jvm]  <br>Content  <br>fun [zAlgorithm](z-algorithm.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br>fun [zAlgorithm](z-algorithm.md)(s: [CharArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br>fun [zAlgorithm](z-algorithm.md)(s: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/lcp-array.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/lcp-array.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.stringAlgorithm](../index.md)/[StringAlgorithm](index.md)/[lcpArray](lcp-array.md)
+
+
+
+# lcpArray  
+[jvm]  
+Content  
+fun [lcpArray](lcp-array.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html), sa: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+fun [lcpArray](lcp-array.md)(s: [CharArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-array/index.html), sa: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+fun [lcpArray](lcp-array.md)(s: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html), sa: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/suffix-array.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/suffix-array.md
@@ -1,0 +1,14 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.stringAlgorithm](../index.md)/[StringAlgorithm](index.md)/[suffixArray](suffix-array.md)
+
+
+
+# suffixArray  
+[jvm]  
+Content  
+fun [suffixArray](suffix-array.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html), upper: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+fun [suffixArray](suffix-array.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+fun [suffixArray](suffix-array.md)(s: [CharArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+fun [suffixArray](suffix-array.md)(s: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/z-algorithm.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/-string-algorithm/z-algorithm.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.stringAlgorithm](../index.md)/[StringAlgorithm](index.md)/[zAlgorithm](z-algorithm.md)
+
+
+
+# zAlgorithm  
+[jvm]  
+Content  
+fun [zAlgorithm](z-algorithm.md)(s: [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+fun [zAlgorithm](z-algorithm.md)(s: [CharArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-array/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+fun [zAlgorithm](z-algorithm.md)(s: [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)): [IntArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int-array/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.stringAlgorithm/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.stringAlgorithm](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.stringAlgorithm  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [StringAlgorithm](-string-algorithm/index.md)| [jvm]  <br>Content  <br>object [StringAlgorithm](-string-algorithm/index.md)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/-init-.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/-init-.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.twoSAT](../index.md)/[TwoSAT](index.md)/[<init>](-init-.md)
+
+
+
+# <init>  
+[jvm]  
+Content  
+fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/add-clause.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/add-clause.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.twoSAT](../index.md)/[TwoSAT](index.md)/[addClause](add-clause.md)
+
+
+
+# addClause  
+[jvm]  
+Content  
+fun [addClause](add-clause.md)(x: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html), y: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), g: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/add-implication.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/add-implication.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.twoSAT](../index.md)/[TwoSAT](index.md)/[addImplication](add-implication.md)
+
+
+
+# addImplication  
+[jvm]  
+Content  
+fun [addImplication](add-implication.md)(x: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html), y: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), g: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/add-nand.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/add-nand.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.twoSAT](../index.md)/[TwoSAT](index.md)/[addNand](add-nand.md)
+
+
+
+# addNand  
+[jvm]  
+Content  
+fun [addNand](add-nand.md)(x: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html), y: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), g: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html))  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/answer.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/answer.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.twoSAT](../index.md)/[TwoSAT](index.md)/[answer](answer.md)
+
+
+
+# answer  
+[jvm]  
+Content  
+fun [answer](answer.md)(): [BooleanArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean-array/index.html)?  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/index.md
@@ -1,0 +1,30 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.twoSAT](../index.md)/[TwoSAT](index.md)
+
+
+
+# TwoSAT  
+ [jvm] convert from [AtCoderLibraryForJava - TwoSAT](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/2SAT/TwoSAT.java)  
+  
+class [TwoSAT](index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   
+
+
+## Constructors  
+  
+|  Name|  Summary| 
+|---|---|
+| [<init>](-init-.md)|  [jvm] fun [<init>](-init-.md)(n: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))   <br>
+
+
+## Functions  
+  
+|  Name|  Summary| 
+|---|---|
+| [addClause](add-clause.md)| [jvm]  <br>Content  <br>fun [addClause](add-clause.md)(x: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html), y: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), g: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html))  <br><br><br>
+| [addImplication](add-implication.md)| [jvm]  <br>Content  <br>fun [addImplication](add-implication.md)(x: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html), y: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), g: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html))  <br><br><br>
+| [addNand](add-nand.md)| [jvm]  <br>Content  <br>fun [addNand](add-nand.md)(x: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), f: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html), y: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html), g: [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html))  <br><br><br>
+| [answer](answer.md)| [jvm]  <br>Content  <br>fun [answer](answer.md)(): [BooleanArray](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean-array/index.html)?  <br><br><br>
+| [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)| [jvm]  <br>Content  <br>open operator override fun [equals](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html)(other: [Any](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/index.html)?): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)| [jvm]  <br>Content  <br>open override fun [hashCode](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/hash-code.html)(): [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)  <br><br><br>
+| [satisfiable](satisfiable.md)| [jvm]  <br>Content  <br>fun [satisfiable](satisfiable.md)(): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  <br><br><br>
+| [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)| [jvm]  <br>Content  <br>open override fun [toString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/to-string.html)(): [String](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)  <br><br><br>
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/satisfiable.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/-two-s-a-t/satisfiable.md
@@ -1,0 +1,11 @@
+//[ac-library-kt](../../index.md)/[jp.atcoder.library.kotlin.twoSAT](../index.md)/[TwoSAT](index.md)/[satisfiable](satisfiable.md)
+
+
+
+# satisfiable  
+[jvm]  
+Content  
+fun [satisfiable](satisfiable.md)(): [Boolean](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)  
+
+
+

--- a/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/index.md
+++ b/docs/ac-library-kt/jp.atcoder.library.kotlin.twoSAT/index.md
@@ -1,0 +1,13 @@
+//[ac-library-kt](../index.md)/[jp.atcoder.library.kotlin.twoSAT](index.md)
+
+
+
+# Package jp.atcoder.library.kotlin.twoSAT  
+
+
+## Types  
+  
+|  Name|  Summary| 
+|---|---|
+| [TwoSAT](-two-s-a-t/index.md)| [jvm]  <br>Brief description  <br>convert from [AtCoderLibraryForJava - TwoSAT](https://github.com/NASU41/AtCoderLibraryForJava/blob/24160d880a5fc6d1caf9b95baa875e47fb568ef3/2SAT/TwoSAT.java)  <br>Content  <br>class [TwoSAT](-two-s-a-t/index.md)(**n**: [Int](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html))  <br><br><br>
+

--- a/docs/ac-library-kt/package-list
+++ b/docs/ac-library-kt/package-list
@@ -1,0 +1,16 @@
+$dokka.format:gfm
+$dokka.linkExtension:md
+
+jp.atcoder.library.kotlin.convolution
+jp.atcoder.library.kotlin.dsu
+jp.atcoder.library.kotlin.fenwickTree
+jp.atcoder.library.kotlin.lazySegTree
+jp.atcoder.library.kotlin.math
+jp.atcoder.library.kotlin.maxFlow
+jp.atcoder.library.kotlin.minCostFlow
+jp.atcoder.library.kotlin.modInt
+jp.atcoder.library.kotlin.scc
+jp.atcoder.library.kotlin.segTree
+jp.atcoder.library.kotlin.stringAlgorithm
+jp.atcoder.library.kotlin.twoSAT
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,8 @@
-rootProject.name = 'ac-library-kt'
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        jcenter()
+    }
+}
 
+rootProject.name = 'ac-library-kt'


### PR DESCRIPTION
# 概要

- #29 ソースコードに記載されたKDocからGFM(git format markdown)形式でドキュメントを書き出すようにしました。  
（現時点で内容がスカスカなのは気にしたら負け...）

思いつきですが、./gradlew dokkaGfm を実行するだけなのでプルリクエストがマージされたときにCIで自動生成すると良いかもしれないですね。

また、github pageで公開するならdokkaJekyllで生成するようにして、下記のページを参考にリポジトリの設定をすると良さそうです。

■publishing-sources-for-github-pages-sites
https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/about-github-pages#publishing-sources-for-github-pages-sites