### PR TITLE
fix ModInt.ModArithmetic, SCC.Edge's visibility.

### DIFF
--- a/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/modInt/ModInt.kt
@@ -82,7 +82,7 @@ class ModIntFactory(private val mod: Int) {
         }
     }
 
-    internal interface ModArithmetic {
+    private interface ModArithmetic {
         fun mod(): Int
         fun add(a: Int, b: Int): Int
         fun sub(a: Int, b: Int): Int

--- a/src/main/kotlin/jp/atcoder/library/kotlin/scc/SCC.kt
+++ b/src/main/kotlin/jp/atcoder/library/kotlin/scc/SCC.kt
@@ -4,7 +4,7 @@ package jp.atcoder.library.kotlin.scc
  * convert from [AtCoderLibraryForJava - SCC](https://github.com/NASU41/AtCoderLibraryForJava/blob/ee794a298f6d16ab24bd9316e7cae8a9155510e5/SCC/SCC.java)
  */
 class SCC(private val n: Int) {
-    internal class Edge(var from: Int, var to: Int)
+    private class Edge(var from: Int, var to: Int)
 
     private var m = 0
     private val unorderedEdges: ArrayList<Edge> = ArrayList()


### PR DESCRIPTION
# 概要
- `ModInt.ModArithmetic`, `SCC.Edge` の可視性修飾子の修正。
  - `ModArithmetic`は`ModInt`経由で使われる設計のため、`internal`->`private`に修正。
  - `SCC.Edge` も中でしか使われていないので`internal`->`private`に修正。